### PR TITLE
fix: prevent backup cleanup from racing with concurrent atomic writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-*No changes yet*
+### Fixed
+
+- **Backup cleanup race condition**: Pre-backup `cleanupOrphanedFiles()` could delete in-flight temp files from concurrent `writeAtomic()` calls, causing `NoSuchFileException` during player data saves ([HYPERFACTIONS-4](https://hypersystems.sentry.io/issues/HYPERFACTIONS-4))
+- **Orphan cleanup safety**: `cleanupOrphanedFiles()` now skips `.tmp` files younger than 5 seconds to prevent racing with active writes
 
 ## [0.10.2] - 2026-02-28
 

--- a/src/main/java/com/hyperfactions/backup/BackupManager.java
+++ b/src/main/java/com/hyperfactions/backup/BackupManager.java
@@ -2,7 +2,6 @@ package com.hyperfactions.backup;
 
 import com.hyperfactions.HyperFactions;
 import com.hyperfactions.config.ConfigManager;
-import com.hyperfactions.storage.StorageUtils;
 import com.hyperfactions.util.Logger;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -254,26 +253,13 @@ public class BackupManager {
       @Nullable UUID createdBy) {
 
     return CompletableFuture.supplyAsync(() -> {
-      // Clean up orphaned .tmp/.bak files before backup
-      Path dataPath = dataDir.resolve("data");
-      Path factionsClean = dataPath.resolve("factions");
-      Path playersClean = dataPath.resolve("players");
-      Path economyClean = dataPath.resolve("economy");
-      Path chatClean = dataPath.resolve("chat");
-      if (Files.exists(factionsClean)) {
-        StorageUtils.cleanupOrphanedFiles(factionsClean);
-      }
-      if (Files.exists(playersClean)) {
-        StorageUtils.cleanupOrphanedFiles(playersClean);
-      }
-      if (Files.exists(economyClean)) {
-        StorageUtils.cleanupOrphanedFiles(economyClean);
-      }
-      if (Files.exists(chatClean)) {
-        StorageUtils.cleanupOrphanedFiles(chatClean);
-      }
+      // Note: pre-backup cleanup of .tmp/.bak files removed — it raced with
+      // concurrent writeAtomic() calls, deleting in-flight temp files and
+      // causing NoSuchFileException (HYPERFACTIONS-4). The ZIP only includes
+      // .json files anyway, and startup init() handles orphan cleanup safely.
 
       // Generate backup name
+      Path dataPath = dataDir.resolve("data");
       Instant timestamp = Instant.now();
       String name;
       if (type == BackupType.MANUAL && customName != null && !customName.isEmpty()) {

--- a/src/main/java/com/hyperfactions/storage/StorageUtils.java
+++ b/src/main/java/com/hyperfactions/storage/StorageUtils.java
@@ -326,8 +326,14 @@ public final class StorageUtils {
         String fileName = file.getFileName().toString();
 
         // Clean up orphaned .tmp files (any file ending in .tmp)
+        // Skip recent files to avoid racing with concurrent writeAtomic() calls
         if (fileName.endsWith(TMP_SUFFIX)) {
           try {
+            long ageMs = System.currentTimeMillis() - Files.getLastModifiedTime(file).toMillis();
+            if (ageMs < 5000) {
+              Logger.debug("[Storage] Skipping recent temp file: %s (age: %dms)", fileName, ageMs);
+              continue;
+            }
             Files.delete(file);
             cleaned++;
             Logger.debug("[Storage] Cleaned orphaned temp file: %s", fileName);


### PR DESCRIPTION
## Description

`BackupManager.createBackup()` called `StorageUtils.cleanupOrphanedFiles()` on all data directories before creating the backup ZIP. This raced with concurrent `writeAtomic()` calls — the cleanup deleted `.tmp` files that were actively being moved, causing `NoSuchFileException` on the rename step and silently dropping player data saves.

**Two fixes applied:**
1. **Removed pre-backup cleanup** — unnecessary since the ZIP only includes `.json` files, and startup `init()` already handles orphan cleanup safely (runs synchronously via `.join()`)
2. **Added 5-second age threshold to `cleanupOrphanedFiles()`** — safety net so that even if cleanup is called from other paths, it won't delete temp files from in-flight writes

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage

## Related Issues

Fixes [HYPERFACTIONS-4](https://hypersystems.sentry.io/issues/HYPERFACTIONS-4)

## Testing

- [x] Tested on local development server
- [ ] Added/updated unit tests
- [x] Verified no regressions in existing functionality

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally with my changes