### PR TITLE
feat: add currency symbol position config option

### DIFF
--- a/src/main/java/com/hyperfactions/config/ConfigManager.java
+++ b/src/main/java/com/hyperfactions/config/ConfigManager.java
@@ -866,6 +866,11 @@ public class ConfigManager {
     return economyConfig.getCurrencySymbol();
   }
 
+  /** Checks if the economy currency symbol should be placed on the right side. */
+  public boolean isEconomyCurrencySymbolRight() {
+    return economyConfig.isSymbolRight();
+  }
+
   @NotNull public java.math.BigDecimal getEconomyStartingBalance() {
     return economyConfig.getStartingBalance();
   }

--- a/src/main/java/com/hyperfactions/config/modules/EconomyConfig.java
+++ b/src/main/java/com/hyperfactions/config/modules/EconomyConfig.java
@@ -26,6 +26,8 @@ public class EconomyConfig extends ModuleConfig {
 
   private String currencySymbol = "$";
 
+  private String currencySymbolPosition = "left";
+
   private BigDecimal startingBalance = BigDecimal.ZERO;
 
   private boolean disbandRefundToLeader = true;
@@ -106,6 +108,7 @@ public class EconomyConfig extends ModuleConfig {
     currencyName = "dollar";
     currencyNamePlural = "dollars";
     currencySymbol = "$";
+    currencySymbolPosition = "left";
     startingBalance = BigDecimal.ZERO;
     disbandRefundToLeader = true;
     defaultMaxWithdrawAmount = BigDecimal.ZERO;
@@ -141,6 +144,7 @@ public class EconomyConfig extends ModuleConfig {
     currencyName = getString(currency, "name", getString(root, "currencyName", currencyName));
     currencyNamePlural = getString(currency, "namePlural", getString(root, "currencyNamePlural", currencyNamePlural));
     currencySymbol = getString(currency, "symbol", getString(root, "currencySymbol", currencySymbol));
+    currencySymbolPosition = getString(currency, "symbolPosition", getString(root, "currencySymbolPosition", currencySymbolPosition));
 
     // Treasury section
     JsonObject treasury = getSection(root, "treasury");
@@ -196,6 +200,7 @@ public class EconomyConfig extends ModuleConfig {
     currency.addProperty("name", currencyName);
     currency.addProperty("namePlural", currencyNamePlural);
     currency.addProperty("symbol", currencySymbol);
+    currency.addProperty("symbolPosition", currencySymbolPosition);
     root.add("currency", currency);
 
     // Treasury section
@@ -287,6 +292,25 @@ public class EconomyConfig extends ModuleConfig {
   @NotNull
   public String getCurrencySymbol() {
     return currencySymbol;
+  }
+
+  /**
+   * Gets the currency symbol position ("left" or "right").
+   *
+   * @return currency symbol position
+   */
+  @NotNull
+  public String getCurrencySymbolPosition() {
+    return currencySymbolPosition;
+  }
+
+  /**
+   * Checks if the currency symbol should be placed on the right side.
+   *
+   * @return true if symbol position is "right"
+   */
+  public boolean isSymbolRight() {
+    return "right".equalsIgnoreCase(currencySymbolPosition);
   }
 
   /**
@@ -459,7 +483,8 @@ public class EconomyConfig extends ModuleConfig {
    */
   @NotNull
   public String format(@NotNull BigDecimal amount) {
-    return currencySymbol + amount.setScale(2, RoundingMode.HALF_UP).toPlainString();
+    String formatted = amount.setScale(2, RoundingMode.HALF_UP).toPlainString();
+    return isSymbolRight() ? formatted + currencySymbol : currencySymbol + formatted;
   }
 
   /**
@@ -501,6 +526,14 @@ public class EconomyConfig extends ModuleConfig {
       result.addWarning(getConfigName(), "currencyNamePlural",
           "Currency name plural should not be empty", currencyNamePlural, "dollars");
       currencyNamePlural = "dollars";
+      needsSave = true;
+    }
+
+    // Currency symbol position must be "left" or "right"
+    if (!"left".equalsIgnoreCase(currencySymbolPosition) && !"right".equalsIgnoreCase(currencySymbolPosition)) {
+      result.addWarning(getConfigName(), "currencySymbolPosition",
+          "Must be 'left' or 'right'", currencySymbolPosition, "left");
+      currencySymbolPosition = "left";
       needsSave = true;
     }
 

--- a/src/main/java/com/hyperfactions/manager/EconomyManager.java
+++ b/src/main/java/com/hyperfactions/manager/EconomyManager.java
@@ -535,7 +535,9 @@ public class EconomyManager implements EconomyAPI {
   @NotNull
   public String formatCurrency(@NotNull BigDecimal amount) {
     String symbol = ConfigManager.get().getEconomyCurrencySymbol();
-    return symbol + amount.setScale(2, RoundingMode.HALF_UP).toPlainString();
+    String formatted = amount.setScale(2, RoundingMode.HALF_UP).toPlainString();
+    return ConfigManager.get().isEconomyCurrencySymbolRight()
+        ? formatted + symbol : symbol + formatted;
   }
 
   /**
@@ -557,14 +559,23 @@ public class EconomyManager implements EconomyAPI {
     BigDecimal thousand = new BigDecimal("1000");
 
     if (abs.compareTo(billion) >= 0) {
-      return String.format("%s%s%.1fB", sign, symbol, abs.divide(billion, 1, RoundingMode.HALF_UP).doubleValue());
+      return applySymbol(sign, symbol, String.format("%.1fB", abs.divide(billion, 1, RoundingMode.HALF_UP).doubleValue()));
     } else if (abs.compareTo(million) >= 0) {
-      return String.format("%s%s%.1fM", sign, symbol, abs.divide(million, 1, RoundingMode.HALF_UP).doubleValue());
+      return applySymbol(sign, symbol, String.format("%.1fM", abs.divide(million, 1, RoundingMode.HALF_UP).doubleValue()));
     } else if (abs.compareTo(tenThousand) >= 0) {
-      return String.format("%s%s%.1fK", sign, symbol, abs.divide(thousand, 1, RoundingMode.HALF_UP).doubleValue());
+      return applySymbol(sign, symbol, String.format("%.1fK", abs.divide(thousand, 1, RoundingMode.HALF_UP).doubleValue()));
     } else {
-      return sign + symbol + abs.setScale(2, RoundingMode.HALF_UP).toPlainString();
+      return applySymbol(sign, symbol, abs.setScale(2, RoundingMode.HALF_UP).toPlainString());
     }
+  }
+
+  /**
+   * Applies the currency symbol to a formatted value, respecting the configured position.
+   */
+  @NotNull
+  private String applySymbol(@NotNull String sign, @NotNull String symbol, @NotNull String value) {
+    return ConfigManager.get().isEconomyCurrencySymbolRight()
+        ? sign + value + symbol : sign + symbol + value;
   }
 
   /** Checks if enabled. */


### PR DESCRIPTION
## Summary
- Add `currency.symbolPosition` config option (`"left"` or `"right"`) to `economy.json`
- Updates all 3 currency formatting methods (`EconomyConfig.format()`, `EconomyManager.formatCurrency()`, `EconomyManager.formatCurrencyCompact()`) to respect the position setting
- Includes input validation that auto-corrects invalid values to `"left"` with a warning
- Existing configs without `symbolPosition` default to `"left"` (backward compatible)

## Config
```json
{
  "currency": {
    "name": "dollar",
    "namePlural": "dollars",
    "symbol": "$",
    "symbolPosition": "left"
  }
}
```

## Files Changed
- `EconomyConfig.java` — field, defaults, load, save, getters, format, validation
- `ConfigManager.java` — gateway method `isEconomyCurrencySymbolRight()`
- `EconomyManager.java` — position-aware `formatCurrency()`, `formatCurrencyCompact()`, `applySymbol()` helper

## Test plan
- [x] Build and deploy with default config — verify `$100.00` format unchanged
- [x] Set `"symbolPosition": "right"` — verify `100.00$` format
- [x] Verify compact formatting: `1.2K$` vs `$1.2K`
- [x] Check dashboard, treasury page, admin economy page, upkeep notifications
- [x] Set invalid value (e.g. `"center"`) — verify auto-corrects to `"left"` with warning
- [x] Verify existing configs without `symbolPosition` default to `"left"`